### PR TITLE
BREAKING(ext/io): remove `Deno.{stdin,stdout,stderr}.rid`

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -2785,15 +2785,6 @@ declare namespace Deno {
    * @category I/O
    */
   export const stdin: Reader & ReaderSync & Closer & {
-    /**
-     * The resource ID assigned to `stdin`. This can be used with the discreet
-     * I/O functions in the `Deno` namespace.
-     *
-     * @deprecated This will be removed in Deno 2.0. See the
-     * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-     * for migration instructions.
-     */
-    readonly rid: number;
     /** A readable stream interface to `stdin`. */
     readonly readable: ReadableStream<Uint8Array>;
     /**
@@ -2833,15 +2824,6 @@ declare namespace Deno {
    * @category I/O
    */
   export const stdout: Writer & WriterSync & Closer & {
-    /**
-     * The resource ID assigned to `stdout`. This can be used with the discreet
-     * I/O functions in the `Deno` namespace.
-     *
-     * @deprecated This will be removed in Deno 2.0. See the
-     * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-     * for migration instructions.
-     */
-    readonly rid: number;
     /** A writable stream interface to `stdout`. */
     readonly writable: WritableStream<Uint8Array>;
     /**
@@ -2867,15 +2849,6 @@ declare namespace Deno {
    * @category I/O
    */
   export const stderr: Writer & WriterSync & Closer & {
-    /**
-     * The resource ID assigned to `stderr`. This can be used with the discreet
-     * I/O functions in the `Deno` namespace.
-     *
-     * @deprecated This will be removed in Deno 2.0. See the
-     * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-     * for migration instructions.
-     */
-    readonly rid: number;
     /** A writable stream interface to `stderr`. */
     readonly writable: WritableStream<Uint8Array>;
     /**

--- a/ext/io/12_io.js
+++ b/ext/io/12_io.js
@@ -188,15 +188,6 @@ class Stdin {
   constructor() {
   }
 
-  get rid() {
-    internals.warnOnDeprecatedApi(
-      "Deno.stdin.rid",
-      new Error().stack,
-      "Use `Deno.stdin` instance methods instead.",
-    );
-    return this.#rid;
-  }
-
   read(p) {
     return read(this.#rid, p);
   }
@@ -233,15 +224,6 @@ class Stdout {
   constructor() {
   }
 
-  get rid() {
-    internals.warnOnDeprecatedApi(
-      "Deno.stdout.rid",
-      new Error().stack,
-      "Use `Deno.stdout` instance methods instead.",
-    );
-    return this.#rid;
-  }
-
   write(p) {
     return write(this.#rid, p);
   }
@@ -271,15 +253,6 @@ class Stderr {
   #writable;
 
   constructor() {
-  }
-
-  get rid() {
-    internals.warnOnDeprecatedApi(
-      "Deno.stderr.rid",
-      new Error().stack,
-      "Use `Deno.stderr` instance methods instead.",
-    );
-    return this.#rid;
   }
 
   write(p) {

--- a/tests/unit/files_test.ts
+++ b/tests/unit/files_test.ts
@@ -12,12 +12,6 @@ import { copy } from "@std/streams/copy.ts";
 
 // Note tests for Deno.FsFile.setRaw is in integration tests.
 
-Deno.test(function filesStdioFileDescriptors() {
-  assertEquals(Deno.stdin.rid, 0);
-  assertEquals(Deno.stdout.rid, 1);
-  assertEquals(Deno.stderr.rid, 2);
-});
-
 Deno.test({ permissions: { read: true } }, async function filesCopyToStdout() {
   const filename = "tests/testdata/assets/fixture.json";
   using file = await Deno.open(filename);

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -364,7 +364,7 @@ Deno.test({
 Deno.test({
   name: "process.stdin",
   fn() {
-    assertEquals(process.stdin.fd, Deno.stdin.rid);
+    assertEquals(process.stdin.fd, 0);
     assertEquals(process.stdin.isTTY, Deno.stdin.isTerminal());
   },
 });
@@ -543,7 +543,7 @@ Deno.test({
 Deno.test({
   name: "process.stdout",
   fn() {
-    assertEquals(process.stdout.fd, Deno.stdout.rid);
+    assertEquals(process.stdout.fd, 1);
     const isTTY = Deno.stdout.isTerminal();
     assertEquals(process.stdout.isTTY, isTTY);
     const consoleSize = isTTY ? Deno.consoleSize() : undefined;
@@ -571,7 +571,7 @@ Deno.test({
 Deno.test({
   name: "process.stderr",
   fn() {
-    assertEquals(process.stderr.fd, Deno.stderr.rid);
+    assertEquals(process.stderr.fd, 2);
     const isTTY = Deno.stderr.isTerminal();
     assertEquals(process.stderr.isTTY, isTTY);
     const consoleSize = isTTY ? Deno.consoleSize() : undefined;

--- a/tests/unit_node/tty_test.ts
+++ b/tests/unit_node/tty_test.ts
@@ -6,9 +6,9 @@ import { isatty } from "node:tty";
 import process from "node:process";
 
 Deno.test("[node/tty isatty] returns true when fd is a tty, false otherwise", () => {
-  assert(Deno.stdin.isTerminal() === isatty(Deno.stdin.rid));
-  assert(Deno.stdout.isTerminal() === isatty(Deno.stdout.rid));
-  assert(Deno.stderr.isTerminal() === isatty(Deno.stderr.rid));
+  assert(Deno.stdin.isTerminal() === isatty(0));
+  assert(Deno.stdout.isTerminal() === isatty(1));
+  assert(Deno.stderr.isTerminal() === isatty(2));
 
   using file = Deno.openSync("README.md");
   assert(!isatty(file.rid));


### PR DESCRIPTION
Early work towards Deno v2. Please do not merge yet.