### PR TITLE
BREAKING(ext/buffer): remove `Deno.readAll[Sync]()`

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -3053,30 +3053,6 @@ declare namespace Deno {
   }
 
   /**
-   * Read Reader `r` until EOF (`null`) and resolve to the content as
-   * Uint8Array`.
-   *
-   * @deprecated This will be removed in Deno 2.0. See the
-   * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-   * for migration instructions.
-   *
-   * @category I/O
-   */
-  export function readAll(r: Reader): Promise<Uint8Array>;
-
-  /**
-   * Synchronously reads Reader `r` until EOF (`null`) and returns the content
-   * as `Uint8Array`.
-   *
-   * @deprecated This will be removed in Deno 2.0. See the
-   * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-   * for migration instructions.
-   *
-   * @category I/O
-   */
-  export function readAllSync(r: ReaderSync): Uint8Array;
-
-  /**
    * Write all the content of the array buffer (`arr`) to the writer (`w`).
    *
    * @deprecated This will be removed in Deno 2.0. See the

--- a/runtime/js/13_buffer.js
+++ b/runtime/js/13_buffer.js
@@ -234,28 +234,6 @@ class Buffer {
   }
 }
 
-async function readAll(r) {
-  internals.warnOnDeprecatedApi(
-    "Deno.readAll()",
-    new Error().stack,
-    "Use `readAll()` from `https://deno.land/std/io/read_all.ts` instead.",
-  );
-  const buf = new Buffer();
-  await buf.readFrom(r);
-  return buf.bytes();
-}
-
-function readAllSync(r) {
-  internals.warnOnDeprecatedApi(
-    "Deno.readAllSync()",
-    new Error().stack,
-    "Use `readAllSync()` from `https://deno.land/std/io/read_all.ts` instead.",
-  );
-  const buf = new Buffer();
-  buf.readFromSync(r);
-  return buf.bytes();
-}
-
 async function writeAll(w, arr) {
   internals.warnOnDeprecatedApi(
     "Deno.writeAll()",
@@ -280,4 +258,4 @@ function writeAllSync(w, arr) {
   }
 }
 
-export { Buffer, readAll, readAllSync, writeAll, writeAllSync };
+export { Buffer, writeAll, writeAllSync };

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -119,8 +119,6 @@ const denoNs = {
   exit: os.exit,
   execPath: os.execPath,
   Buffer: buffer.Buffer,
-  readAll: buffer.readAll,
-  readAllSync: buffer.readAllSync,
   writeAll: buffer.writeAll,
   writeAllSync: buffer.writeAllSync,
   copy: io.copy,

--- a/tests/unit/buffer_test.ts
+++ b/tests/unit/buffer_test.ts
@@ -352,28 +352,6 @@ Deno.test(async function bufferTestGrow() {
   }
 });
 
-Deno.test(async function testReadAll() {
-  init();
-  assert(testBytes);
-  const reader = new Deno.Buffer(testBytes.buffer as ArrayBuffer);
-  const actualBytes = await Deno.readAll(reader);
-  assertEquals(testBytes.byteLength, actualBytes.byteLength);
-  for (let i = 0; i < testBytes.length; ++i) {
-    assertEquals(testBytes[i], actualBytes[i]);
-  }
-});
-
-Deno.test(function testReadAllSync() {
-  init();
-  assert(testBytes);
-  const reader = new Deno.Buffer(testBytes.buffer as ArrayBuffer);
-  const actualBytes = Deno.readAllSync(reader);
-  assertEquals(testBytes.byteLength, actualBytes.byteLength);
-  for (let i = 0; i < testBytes.length; ++i) {
-    assertEquals(testBytes[i], actualBytes[i]);
-  }
-});
-
 Deno.test(async function testWriteAll() {
   init();
   assert(testBytes);

--- a/tests/unit/command_test.ts
+++ b/tests/unit/command_test.ts
@@ -59,7 +59,13 @@ Deno.test(
     const command = new Deno.Command(Deno.execPath(), {
       args: [
         "eval",
-        "if (new TextDecoder().decode(await Deno.readAll(Deno.stdin)) !== 'hello') throw new Error('Expected \\'hello\\'')",
+        `
+        const buffer = new Uint8Array(5);
+        Deno.stdin.read(buffer);
+        if (new TextDecoder().decode(buffer) !== "hello") {
+          throw new Error('Expected \\'hello\\'')
+        }
+        `
       ],
       stdin: "piped",
       stdout: "null",
@@ -214,7 +220,13 @@ Deno.test(
     const command = new Deno.Command(Deno.execPath(), {
       args: [
         "eval",
-        "if (new TextDecoder().decode(await Deno.readAll(Deno.stdin)) !== 'hello') throw new Error('Expected \\'hello\\'')",
+        `
+        const buffer = new Uint8Array(5);
+        Deno.stdin.read(buffer);
+        if (new TextDecoder().decode(buffer) !== "hello") {
+          throw new Error('Expected \\'hello\\'')
+        }
+        `
       ],
       stdin: "piped",
       stdout: "null",

--- a/tests/unit/command_test.ts
+++ b/tests/unit/command_test.ts
@@ -65,7 +65,7 @@ Deno.test(
         if (new TextDecoder().decode(buffer) !== "hello") {
           throw new Error('Expected \\'hello\\'')
         }
-        `
+        `,
       ],
       stdin: "piped",
       stdout: "null",
@@ -226,7 +226,7 @@ Deno.test(
         if (new TextDecoder().decode(buffer) !== "hello") {
           throw new Error('Expected \\'hello\\'')
         }
-        `
+        `,
       ],
       stdin: "piped",
       stdout: "null",

--- a/tests/unit/process_test.ts
+++ b/tests/unit/process_test.ts
@@ -220,7 +220,13 @@ Deno.test(
       cmd: [
         Deno.execPath(),
         "eval",
-        "if (new TextDecoder().decode(await Deno.readAll(Deno.stdin)) !== 'hello') throw new Error('Expected \\'hello\\'')",
+        `
+        const buffer = new Uint8Array(5);
+        Deno.stdin.read(buffer);
+        if (new TextDecoder().decode(buffer) !== "hello") {
+          throw new Error('Expected \\'hello\\'')
+        }
+        `
       ],
       stdin: "piped",
     });
@@ -402,7 +408,13 @@ Deno.test(
       cmd: [
         Deno.execPath(),
         "eval",
-        "if (new TextDecoder().decode(await Deno.readAll(Deno.stdin)) !== 'hello') throw new Error('Expected \\'hello\\'')",
+        `
+        const buffer = new Uint8Array(5);
+        Deno.stdin.read(buffer);
+        if (new TextDecoder().decode(buffer) !== "hello") {
+          throw new Error('Expected \\'hello\\'')
+        }
+        `
       ],
       stdin: file.rid,
     });

--- a/tests/unit/process_test.ts
+++ b/tests/unit/process_test.ts
@@ -226,7 +226,7 @@ Deno.test(
         if (new TextDecoder().decode(buffer) !== "hello") {
           throw new Error('Expected \\'hello\\'')
         }
-        `
+        `,
       ],
       stdin: "piped",
     });
@@ -414,7 +414,7 @@ Deno.test(
         if (new TextDecoder().decode(buffer) !== "hello") {
           throw new Error('Expected \\'hello\\'')
         }
-        `
+        `,
       ],
       stdin: file.rid,
     });


### PR DESCRIPTION
Early work towards Deno v2. Please do not merge yet.