### PR TITLE
chore: make node setup script less sensitive to changes

### DIFF
--- a/tools/node_compat/TODO.md
+++ b/tools/node_compat/TODO.md
@@ -3,8 +3,6 @@
 
 NOTE: This file should not be manually edited. Please edit `tests/node_compat/config.json` and run `deno task setup` in `tools/node_compat` dir instead.
 
-Total: 2998
-
 - [abort/test-abort-backtrace.js](https://github.com/nodejs/node/tree/v18.12.1/test/abort/test-abort-backtrace.js)
 - [abort/test-abort-fatal-error.js](https://github.com/nodejs/node/tree/v18.12.1/test/abort/test-abort-fatal-error.js)
 - [abort/test-abort-uncaught-exception.js](https://github.com/nodejs/node/tree/v18.12.1/test/abort/test-abort-uncaught-exception.js)

--- a/tools/node_compat/setup.ts
+++ b/tools/node_compat/setup.ts
@@ -78,8 +78,6 @@ async function updateToDo() {
 
 NOTE: This file should not be manually edited. Please edit \`tests/node_compat/config.json\` and run \`deno task setup\` in \`tools/node_compat\` dir instead.
 
-Total: ${missingTests.length}
-
 `));
   for (const test of missingTests) {
     await file.write(


### PR DESCRIPTION
This change tweaks the Node setup script less sensitive to changes by removing the test counter line in `tools/node_compat/TODO.md`. Previously, this line would cause linting issues when two Node compat changes occured one after another.

See https://github.com/denoland/deno/actions/runs/8226735149/job/22493585874